### PR TITLE
Publish both editions when the book changes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,54 @@
+# Rebuild both editions of the book and deploy them to Firebase Hosting on every
+# push to main.
+#
+# The build itself lives in bookish-reader, alongside the binder it runs:
+# https://github.com/amyjko/bookish-reader/blob/main/PUBLISHING.md
+#
+# This replaces two auto-generated workflows that were deleted in dac6911
+# because they deployed firebase.json's `public` directory without ever building
+# it -- and `build` is gitignored, so `channelId: live` would have published an
+# empty folder over the book. The called workflow binds first and refuses to
+# deploy unless every edition in editions.json is actually present.
+#
+# publish.sh still works and is still the way to preview locally
+# (`./publish.sh preview`, which serves the merged build through the Firebase
+# emulator) or to deploy by hand.
+name: Publish
+
+'on':
+    push:
+        branches: [main]
+    workflow_dispatch:
+        inputs:
+            dry-run:
+                description: Build and check the editions, but deploy nothing.
+                type: boolean
+                default: false
+            reader-ref:
+                description: The bookish-reader ref to build with.
+                type: string
+                default: main
+
+# Half a deploy is a broken book, so never cancel one that is already running.
+# GitHub keeps only the newest *queued* run, so the latest push still wins.
+concurrency:
+    group: publish-${{ github.ref }}
+    cancel-in-progress: false
+
+permissions:
+    contents: read
+
+jobs:
+    publish:
+        uses: amyjko/bookish-reader/.github/workflows/publish-book.yml@main
+        with:
+            deploy: firebase
+            # Both editions at once: the 2nd at the root, the 1st under /1,
+            # merged into the one tree firebase.json serves as `build`.
+            manifest: editions.json
+            firebase-project: critically-conscious-computing
+            verify-url: https://critically-conscious-computing.web.app/
+            dry-run: ${{ inputs.dry-run == true }}
+            reader-ref: ${{ inputs.reader-ref || 'main' }}
+        secrets:
+            FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CRITICALLY_CONSCIOUS_COMPUTING }}

--- a/publish.sh
+++ b/publish.sh
@@ -6,6 +6,11 @@ if [ -d "bookish-reader" ]
 then
     rm -rf bookish-reader
 fi
+# Remove the clone however this script exits. set -e means a failed bind or a
+# failed deploy would otherwise skip the cleanup at the end and strand a copy
+# here -- and they are well over a gigabyte each.
+BOOK=$PWD
+trap 'rm -rf "$BOOK/bookish-reader"' EXIT
 # Clone the reader.
 git clone https://github.com/amyjko/bookish-reader
 cd bookish-reader
@@ -19,10 +24,3 @@ then
 else
     firebase deploy
 fi
-
-# Back to the book directory before cleaning up. The clone lives here, not
-# inside itself, and without this the rm below looked for
-# bookish-reader/bookish-reader and silently left the clone behind -- one more
-# copy per run, gigabytes of them.
-cd ..
-rm -rf bookish-reader


### PR DESCRIPTION
A push to `main` now binds both editions and deploys them to Firebase Hosting, instead of waiting for someone to run `publish.sh` on a laptop.

This is the CI deploy that `dac6911` said would have to be done properly. Those two auto-generated workflows deployed `firebase.json`'s `public` directory without ever building it — and `build` is gitignored, so `channelId: live` would have published an empty folder over the book. This one binds first, and refuses to deploy unless every edition in `editions.json` is actually present: the 2nd at the root and the 1st under `/1`, each with its pages, its 404, its bundle, and at least as many pages as chapters. I ran that check against the real two-edition build — it passes both and correctly refuses when one is missing.

It reuses the existing `FIREBASE_SERVICE_ACCOUNT_CRITICALLY_CONSCIOUS_COMPUTING` secret. Worth confirming that service account still holds Firebase Hosting Admin before merging — and **not** by re-running `firebase init hosting:github`, which is what wrote the two broken workflows in the first place.

`publish.sh` also now cleans up after itself on every path. `set -e` meant a failed bind or a failed deploy skipped the cleanup at the end and stranded a copy of the reader here, and they are well over a gigabyte each.

**Merging is what triggers the first deploy, and this secret already exists — so unlike the other books, merging here publishes for real immediately.** Worth watching a UW book succeed first, then running this one by hand with **dry-run**.

Depends on amyjko/bookish-reader#4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)